### PR TITLE
Impr ast

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ LIBS    = libft/libft.a
 INCLUDE = -I./include -I./libft/include -I $(brew --prefix readline)/include
 NAME    = minishell
 SRCDIR  = src
-SRCS    = src/lexer/lexer_helper.c src/lexer/lexer.c src/utils/error.c src/heredoc/heredoc.c src/parser/ast.c src/parser/parser.c src/main.c src/exec/file_access_util.c src/exec/exec.c src/exec/list_to_array.c src/exec/execute_cmd.c src/executor/executor.c src/builtin/env_lst_operations.c src/builtin/decompress.c src/builtin/mini_echo.c src/builtin/mini_cd.c src/builtin/mini_export.c src/builtin/mini_handle_command.c src/builtin/mini_unset.c src/builtin/mini_env.c src/builtin/mini_pwd.c src/builtin/mini_exit.c
+SRCS    = src/lexer/lexer_helper.c src/lexer/lexer.c src/utils/print_ast.c src/utils/error.c src/heredoc/heredoc.c src/parser/ast.c src/parser/parser.c src/main.c src/exec/file_access_util.c src/exec/exec.c src/exec/list_to_array.c src/exec/execute_cmd.c src/builtin/env_lst_operations.c src/builtin/decompress.c src/builtin/mini_echo.c src/builtin/mini_cd.c src/builtin/mini_export.c src/builtin/mini_handle_command.c src/builtin/mini_unset.c src/builtin/mini_env.c src/builtin/mini_pwd.c src/builtin/mini_exit.c
 OBJDIR  = obj
 OBJS    = $(subst $(SRCDIR), $(OBJDIR), $(SRCS:.c=.o))
 DEPENDS = $(OBJS:.o=.d)

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: tsishika <tsishika@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/20 10:55:41 by tkuramot          #+#    #+#             */
-/*   Updated: 2023/09/03 22:41:46 by tsishika         ###   ########.fr       */
+/*   Updated: 2023/09/14 22:49:35 by tkuramot         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,5 +15,7 @@
 
 # include "builtin.h"
 # include "exec.h"
+
+# define DEBUG 0
 
 #endif

--- a/include/parser.h
+++ b/include/parser.h
@@ -6,12 +6,16 @@
 /*   By: tkuramot <tkuramot@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/24 12:19:42 by tkuramot          #+#    #+#             */
-/*   Updated: 2023/09/03 18:13:36 by tkuramot         ###   ########.fr       */
+/*   Updated: 2023/09/14 22:15:49 by tkuramot         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef PARSER_H
 # define PARSER_H
+
+# define STR_PIPE "|"
+# define STR_REDIRECT_IN "<"
+# define STR_REDIRECT_OUT ">"
 
 # include "libft.h"
 # include "lexer.h"
@@ -35,6 +39,5 @@ t_ast	*ast_new_node(t_node_type type, t_ast *left, t_ast *right);
 t_ast	*ast_new_node_cmd(t_token *lst);
 t_ast	*parse_token(t_token *lst);
 t_ast	*parse_pipe(t_token *lst);
-t_ast	*parse_cmd(t_token **lst);
 
 #endif

--- a/include/parser.h
+++ b/include/parser.h
@@ -6,7 +6,7 @@
 /*   By: tkuramot <tkuramot@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/24 12:19:42 by tkuramot          #+#    #+#             */
-/*   Updated: 2023/09/14 22:15:49 by tkuramot         ###   ########.fr       */
+/*   Updated: 2023/09/14 22:27:03 by tkuramot         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,8 +14,8 @@
 # define PARSER_H
 
 # define STR_PIPE "|"
-# define STR_REDIRECT_IN "<"
-# define STR_REDIRECT_OUT ">"
+# define STR_REDIR_IN "<"
+# define STR_REDIR_OUT ">"
 
 # include "libft.h"
 # include "lexer.h"
@@ -23,7 +23,9 @@
 typedef enum e_node_type
 {
 	ND_CMD,
-	ND_PIPE
+	ND_PIPE,
+	ND_REDIR_IN,
+	ND_REDIR_OUT,
 } t_node_type;
 
 typedef struct s_ast t_ast;
@@ -38,6 +40,5 @@ struct s_ast
 t_ast	*ast_new_node(t_node_type type, t_ast *left, t_ast *right);
 t_ast	*ast_new_node_cmd(t_token *lst);
 t_ast	*parse_token(t_token *lst);
-t_ast	*parse_pipe(t_token *lst);
 
 #endif

--- a/include/utils.h
+++ b/include/utils.h
@@ -6,13 +6,16 @@
 /*   By: tkuramot <tkuramot@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/20 11:02:32 by tkuramot          #+#    #+#             */
-/*   Updated: 2023/09/10 21:05:25 by tkuramot         ###   ########.fr       */
+/*   Updated: 2023/09/14 22:31:53 by tkuramot         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef UTILS_H
 # define UTILS_H
 
+#include "parser.h"
+
 void	fatal_error(char *err);
+void	print_ast(t_ast *ast);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: tsishika <tsishika@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/19 17:33:13 by tkuramot          #+#    #+#             */
-/*   Updated: 2023/09/14 20:30:19 by tkuramot         ###   ########.fr       */
+/*   Updated: 2023/09/14 22:49:58 by tkuramot         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,7 @@
 #include "lexer.h"
 #include "parser.h"
 #include "exec.h"
+#include "utils.h"
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -51,10 +52,15 @@ int	main(void)
 			add_history(line);
 			lst = tokenize(line);
 			ast = parse_token(lst);
-			execute(ast, env_lst);
+			#if DEBUG == 1
+				print_ast(ast);
+				(void)env_lst;
+			#else
+				execute(ast, env_lst);
+			#endif
+			free(line);
+			token_lst_free(lst);
 		}
-		free(line);
-		token_lst_free(lst);
 	}
 	return (0);
 }

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,21 +6,30 @@
 /*   By: tkuramot <tkuramot@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/02 23:57:29 by tkuramot          #+#    #+#             */
-/*   Updated: 2023/09/10 21:04:55 by tkuramot         ###   ########.fr       */
+/*   Updated: 2023/09/14 22:18:55 by tkuramot         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "parser.h"
 #include "utils.h"
 
-bool	expect_pipe(t_token *lst)
+static bool	exepect_next(t_token *lst, char *op)
 {
 	if (!lst || !lst->next)
 		return (false);
-	return (ft_strcmp(lst->next->word, "|") == 0);
+	return (ft_strcmp(lst->next->word, op) == 0);
 }
 
-t_ast	*parse_cmd(t_token **lst)
+static bool	exepect_next_simple_token(t_token *lst)
+{
+	if (!lst || !lst->next)
+		return (false);
+	return (!exepect_next(lst, STR_PIPE)
+		&& !exepect_next(lst, STR_REDIRECT_IN)
+		&& !exepect_next(lst, STR_REDIRECT_OUT));
+}
+
+static t_ast	*extract_cmd(t_token **lst)
 {
 	t_token	*cmd;
 	t_token	*tmp;
@@ -29,35 +38,28 @@ t_ast	*parse_cmd(t_token **lst)
 		return (NULL);
 	cmd = *lst;
 	tmp = *lst;
-	while (tmp->next && !expect_pipe(tmp))
-	{
+	while (exepect_next_simple_token(tmp))
 		tmp = tmp->next;
-	}
 	*lst = tmp->next;
 	tmp->next = NULL;
 	return (ast_new_node_cmd(cmd));
 }
 
-t_ast	*parse_pipe(t_token *lst)
+t_ast	*parse_token(t_token *lst)
 {
 	t_ast	*node;
 
-	node = parse_cmd(&lst);
+	node = extract_cmd(&lst);
 	if (!node)
 		fatal_error("malloc");
 	while (true)
 	{
-		if (lst && ft_strcmp(lst->word, "|") == 0)
+		if (lst && ft_strcmp(lst->word, STR_PIPE) == 0)
 		{
 			lst = lst->next;
-			node = ast_new_node(ND_PIPE, node, parse_cmd(&lst));
+			node = ast_new_node(ND_PIPE, node, extract_cmd(&lst));
 		}
 		else
 			return (node);
 	}
-}
-
-t_ast	*parse_token(t_token *lst)
-{
-	return (parse_pipe(lst));
 }

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: tkuramot <tkuramot@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/02 23:57:29 by tkuramot          #+#    #+#             */
-/*   Updated: 2023/09/14 22:18:55 by tkuramot         ###   ########.fr       */
+/*   Updated: 2023/09/14 22:27:34 by tkuramot         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,8 +25,8 @@ static bool	exepect_next_simple_token(t_token *lst)
 	if (!lst || !lst->next)
 		return (false);
 	return (!exepect_next(lst, STR_PIPE)
-		&& !exepect_next(lst, STR_REDIRECT_IN)
-		&& !exepect_next(lst, STR_REDIRECT_OUT));
+		&& !exepect_next(lst, STR_REDIR_IN)
+		&& !exepect_next(lst, STR_REDIR_OUT));
 }
 
 static t_ast	*extract_cmd(t_token **lst)
@@ -58,6 +58,16 @@ t_ast	*parse_token(t_token *lst)
 		{
 			lst = lst->next;
 			node = ast_new_node(ND_PIPE, node, extract_cmd(&lst));
+		}
+		else if (lst && ft_strcmp(lst->word, STR_REDIR_IN) == 0)
+		{
+			lst = lst->next;
+			node = ast_new_node(ND_REDIR_IN, node, extract_cmd(&lst));
+		}
+		else if (lst && ft_strcmp(lst->word, STR_REDIR_OUT) == 0)
+		{
+			lst = lst->next;
+			node = ast_new_node(ND_REDIR_OUT, node, extract_cmd(&lst));
 		}
 		else
 			return (node);

--- a/src/utils/print_ast.c
+++ b/src/utils/print_ast.c
@@ -1,18 +1,18 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   executor.c                                         :+:      :+:    :+:   */
+/*   print_ast.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: tkuramot <tkuramot@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2023/09/03 18:51:37 by tkuramot          #+#    #+#             */
-/*   Updated: 2023/09/09 18:22:20 by tkuramot         ###   ########.fr       */
+/*   Created: 2023/09/14 22:30:17 by tkuramot          #+#    #+#             */
+/*   Updated: 2023/09/14 22:31:41 by tkuramot         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "parser.h"
 
-void	execute_cmd(t_ast *ast)
+void	print_ast(t_ast *ast)
 {
 	t_token	*lst;
 
@@ -26,6 +26,6 @@ ft_dprintf(STDOUT_FILENO, "NODE TYPE is %d\n", ast->type);
 	ft_dprintf(STDOUT_FILENO, "[%s]\n", lst->word);
 		lst = lst->next;
 	}
-	execute_cmd(ast->left);
-	execute_cmd(ast->right);
+	print_ast(ast->left);
+	print_ast(ast->right);
 }


### PR DESCRIPTION
### Issue
#22 

### やったこと
redirect実装しやすいようにastに、redirectのノードを作った。
あとデバッグ用に、`minishell.h`にマクロ定義した。
切り替えれば、コマンド実行とastの表示どっちもできる。
astの表示は見づらいけど。

あとバグ直した。
lineとかtoken listをfreeする関数の位置が悪くて二重解放してた。
![D6C23FDF-7D75-4DDA-839E-0AAD1F615449](https://github.com/K4-R4/minishell/assets/106866329/f42ecc59-9433-47b4-9d1a-5d54009c280e)
<img width="663" alt="スクリーンショット 2023-09-14 22 49 22" src="https://github.com/K4-R4/minishell/assets/106866329/1bdd36d0-bdbf-4850-b18d-3bb7af3b6a66">
