### PR TITLE
Parser redir

### DIFF
--- a/file
+++ b/file
@@ -1,0 +1,65 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   main.c                                             :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tsishika <tsishika@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/08/19 17:33:13 by tkuramot          #+#    #+#             */
+/*   Updated: 2023/09/17 13:25:55 by tkuramot         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+#include "lexer.h"
+#include "parser.h"
+#include "exec.h"
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <readline/readline.h>
+
+static void	print_minishell(void)
+{
+	ft_dprintf(STDERR_FILENO, "                                   __              ___    ___\n");
+	ft_dprintf(STDERR_FILENO, "           __          __         /\\ \\            /\\_ \\  /\\_ \\\n");
+	ft_dprintf(STDERR_FILENO, "  ___ ___ /\\_\\    ___ /\\_\\    ____\\ \\ \\___      __\\//\\ \\ \\//\\ \\\n");
+	ft_dprintf(STDERR_FILENO, "/' __` __`\\/\\ \\ /' _ `\\/\\ \\  /',__\\\\ \\  _ `\\  /'__`\\\\ \\ \\  \\ \\ \\\n");
+	ft_dprintf(STDERR_FILENO, "/\\ \\/\\ \\/\\ \\ \\ \\/\\ \\/\\ \\ \\ \\/\\__, `\\\\ \\ \\ \\ \\/\\  __/ \\_\\ \\_ \\_\\ \\_\n");
+	ft_dprintf(STDERR_FILENO, "\\ \\_\\ \\_\\ \\_\\ \\_\\ \\_\\ \\_\\ \\_\\/\\____/ \\ \\_\\ \\_\\ \\____\\/\\____\\/\\____\\\n");
+	ft_dprintf(STDERR_FILENO, " \\/_/\\/_/\\/_/\\/_/\\/_/\\/_/\\/_/\\/___/   \\/_/\\/_/\\/____/\\/____/\\/____/\n\n");
+}
+
+int	main(void)
+{
+	char	*line;
+	t_token	*lst;
+	t_ast	*ast;
+	extern char	**environ;
+	t_env		*env_lst;
+
+	print_minishell();
+	env_lst = env_lst_init();
+	rl_outstream = stderr;
+	while (true)
+	{
+		line = readline("\x1b[32mminishell$ \x1b[0m");
+		if (!line)
+			return (1);
+		if (*line)
+		{
+			add_history(line);
+			lst = tokenize(line);
+			ast = parse_token(lst);
+			execute(ast, env_lst);
+			free(line);
+			token_lst_free(lst);
+		}
+	}
+	return (0);
+}
+
+// __attribute__((destructor)) static void destructor()
+// {
+//     system("leaks -q minishell");
+// }

--- a/include/lexer.h
+++ b/include/lexer.h
@@ -6,7 +6,7 @@
 /*   By: tsishika <tsishika@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/24 12:19:08 by tkuramot          #+#    #+#             */
-/*   Updated: 2023/09/03 18:29:07 by tkuramot         ###   ########.fr       */
+/*   Updated: 2023/09/18 22:44:22 by tkuramot         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,8 +20,12 @@
 typedef enum e_token_type
 {
 	TK_WORD,
-	TK_OP,
-	TK_EOF
+	TK_PIPE,
+	TK_REDIR_IN,
+	TK_REDIR_OUT,
+	TK_REDIR_APPEND,
+	TK_REDIR_HEREDOC,
+	TK_EOF,
 }	t_token_type;
 
 typedef struct s_token	t_token;

--- a/include/lexer.h
+++ b/include/lexer.h
@@ -6,7 +6,7 @@
 /*   By: tsishika <tsishika@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/24 12:19:08 by tkuramot          #+#    #+#             */
-/*   Updated: 2023/09/18 22:44:22 by tkuramot         ###   ########.fr       */
+/*   Updated: 2023/09/18 23:24:28 by tkuramot         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,7 +43,7 @@ bool	is_metacharacter(char c);
 bool	start_with(char *s, const char *prefix);
 bool	is_word(char c);
 void	consume_blank(char **line);
-
+t_token	*token_copy(t_token *token);
 void	token_lst_free(t_token *lst);
 
 #endif

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,12 +6,14 @@
 /*   By: tsishika <tsishika@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/20 10:55:41 by tkuramot          #+#    #+#             */
-/*   Updated: 2023/09/03 22:41:46 by tsishika         ###   ########.fr       */
+/*   Updated: 2023/09/18 23:06:00 by tkuramot         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef MINISHELL_H
 # define MINISHELL_H
+
+# define DEBUG 1
 
 # include "builtin.h"
 # include "exec.h"

--- a/include/parser.h
+++ b/include/parser.h
@@ -6,7 +6,7 @@
 /*   By: tkuramot <tkuramot@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/24 12:19:42 by tkuramot          #+#    #+#             */
-/*   Updated: 2023/09/03 18:13:36 by tkuramot         ###   ########.fr       */
+/*   Updated: 2023/09/18 22:29:15 by tkuramot         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,6 +26,10 @@ typedef struct s_ast t_ast;
 struct s_ast
 {
 	t_node_type	type;
+	char		*exe;
+	char		*cmd;
+	t_list		*red_in;
+	t_list		*red_out;
 	t_ast		*left;
 	t_ast		*right;
 	t_token		*lst;
@@ -34,7 +38,5 @@ struct s_ast
 t_ast	*ast_new_node(t_node_type type, t_ast *left, t_ast *right);
 t_ast	*ast_new_node_cmd(t_token *lst);
 t_ast	*parse_token(t_token *lst);
-t_ast	*parse_pipe(t_token *lst);
-t_ast	*parse_cmd(t_token **lst);
 
 #endif

--- a/include/parser.h
+++ b/include/parser.h
@@ -6,7 +6,7 @@
 /*   By: tkuramot <tkuramot@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/24 12:19:42 by tkuramot          #+#    #+#             */
-/*   Updated: 2023/09/18 22:38:05 by tkuramot         ###   ########.fr       */
+/*   Updated: 2023/09/18 22:58:21 by tkuramot         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,6 +29,8 @@ struct s_ast
 	t_token		*argv;
 	t_list		*red_in;
 	t_list		*red_out;
+	t_list		*red_heredoc;
+	t_list		*red_append;
 	t_ast		*left;
 	t_ast		*right;
 	t_token		*lst;

--- a/include/parser.h
+++ b/include/parser.h
@@ -6,7 +6,7 @@
 /*   By: tkuramot <tkuramot@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/24 12:19:42 by tkuramot          #+#    #+#             */
-/*   Updated: 2023/09/18 22:29:15 by tkuramot         ###   ########.fr       */
+/*   Updated: 2023/09/18 22:38:05 by tkuramot         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,8 +26,7 @@ typedef struct s_ast t_ast;
 struct s_ast
 {
 	t_node_type	type;
-	char		*exe;
-	char		*cmd;
+	t_token		*argv;
 	t_list		*red_in;
 	t_list		*red_out;
 	t_ast		*left;

--- a/include/utils.h
+++ b/include/utils.h
@@ -6,7 +6,7 @@
 /*   By: tkuramot <tkuramot@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/20 11:02:32 by tkuramot          #+#    #+#             */
-/*   Updated: 2023/09/10 21:05:25 by tkuramot         ###   ########.fr       */
+/*   Updated: 2023/09/18 22:31:42 by tkuramot         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,5 +14,6 @@
 # define UTILS_H
 
 void	fatal_error(char *err);
+void	syntax_error(char *location);
 
 #endif

--- a/src/lexer/lexer.c
+++ b/src/lexer/lexer.c
@@ -6,7 +6,7 @@
 /*   By: tsishika <tsishika@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/24 12:20:26 by tkuramot          #+#    #+#             */
-/*   Updated: 2023/09/18 22:47:44 by tkuramot         ###   ########.fr       */
+/*   Updated: 2023/09/18 23:24:43 by tkuramot         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,6 +26,11 @@ static t_token	*token_init(char *word, t_token_type type)
 	token->word = word;
 	token->type = type;
 	return (token);
+}
+
+t_token	*token_copy(t_token *token)
+{
+	return (token_init(token->word, token->type));
 }
 
 static t_token	*extract_word(char **line)

--- a/src/lexer/lexer.c
+++ b/src/lexer/lexer.c
@@ -6,7 +6,7 @@
 /*   By: tsishika <tsishika@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/24 12:20:26 by tkuramot          #+#    #+#             */
-/*   Updated: 2023/09/14 20:30:01 by tkuramot         ###   ########.fr       */
+/*   Updated: 2023/09/18 22:47:44 by tkuramot         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -45,10 +45,11 @@ static t_token	*extract_word(char **line)
 
 static t_token	*extract_metacharacter(char **line)
 {
-	const char	*ops[] = {"|", "<", ">"};
+	const char	*ops[] = {"|", "<<", ">>", "<", ">"};
+	const int	token_type[] = {TK_PIPE, TK_REDIR_HEREDOC, TK_REDIR_APPEND,
+			TK_REDIR_IN, TK_REDIR_OUT};
 	char		*word;
 	size_t		i;
-	t_token		*token;
 
 	i = 0;
 	word = NULL;
@@ -61,9 +62,8 @@ static t_token	*extract_metacharacter(char **line)
 		}
 		i++;
 	}
-	token = token_init(word, TK_OP);
 	*line += ft_strlen(ops[i]);
-	return (token);
+	return (token_init(word, token_type[i]));
 }
 
 t_token	*tokenize(char *line)

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: tsishika <tsishika@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/19 17:33:13 by tkuramot          #+#    #+#             */
-/*   Updated: 2023/09/17 13:25:55 by tkuramot         ###   ########.fr       */
+/*   Updated: 2023/09/18 23:06:49 by tkuramot         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,9 +51,48 @@ int	main(void)
 			add_history(line);
 			lst = tokenize(line);
 			ast = parse_token(lst);
+			# if DEBUG == 1
+			(void)env_lst;
+			printf("REDIRECT IN >\n");
+			while (ast->red_in)
+			{
+				printf("[%s]\n", (char *)ast->red_in->content);
+				ast->red_in = ast->red_in->next;
+			}
+
+			printf("REDIRECT OUT >\n");
+			while (ast->red_out)
+			{
+				printf("[%s]\n", (char *)ast->red_out->content);
+				ast->red_out = ast->red_out->next;
+			}
+
+			printf("REDIRECT HEREDOC >\n");
+			while (ast->red_heredoc)
+			{
+				printf("[%s]\n", (char *)ast->red_heredoc->content);
+				ast->red_heredoc = ast->red_heredoc->next;
+			}
+
+			printf("REDIRECT APPEND >\n");
+			while (ast->red_append)
+			{
+				printf("[%s]\n", (char *)ast->red_append->content);
+				ast->red_append = ast->red_append->next;
+			}
+
+			printf("ARGV >\n");
+			while (ast->argv)
+			{
+				printf("[%s]\n", ast->argv->word);
+				ast->argv = ast->argv->next;
+			}
+
+			# else
 			execute(ast, env_lst);
 			free(line);
 			token_lst_free(lst);
+			# endif
 		}
 	}
 	return (0);

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,22 +6,23 @@
 /*   By: tkuramot <tkuramot@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/02 23:57:29 by tkuramot          #+#    #+#             */
-/*   Updated: 2023/09/10 21:04:55 by tkuramot         ###   ########.fr       */
+/*   Updated: 2023/09/18 22:30:07 by tkuramot         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "parser.h"
 #include "utils.h"
 
-bool	expect_pipe(t_token *lst)
+static bool	expect_pipe(t_token *lst)
 {
 	if (!lst || !lst->next)
 		return (false);
 	return (ft_strcmp(lst->next->word, "|") == 0);
 }
 
-t_ast	*parse_cmd(t_token **lst)
+static t_ast	*parse_cmd(t_token **lst)
 {
+	t_ast	*node;
 	t_token	*cmd;
 	t_token	*tmp;
 
@@ -30,15 +31,14 @@ t_ast	*parse_cmd(t_token **lst)
 	cmd = *lst;
 	tmp = *lst;
 	while (tmp->next && !expect_pipe(tmp))
-	{
 		tmp = tmp->next;
-	}
 	*lst = tmp->next;
 	tmp->next = NULL;
-	return (ast_new_node_cmd(cmd));
+	node = ast_new_node_cmd(cmd);
+	return (node);
 }
 
-t_ast	*parse_pipe(t_token *lst)
+t_ast	*parse_token(t_token *lst)
 {
 	t_ast	*node;
 
@@ -55,9 +55,5 @@ t_ast	*parse_pipe(t_token *lst)
 		else
 			return (node);
 	}
-}
-
-t_ast	*parse_token(t_token *lst)
-{
-	return (parse_pipe(lst));
+	return (parse_token(lst));
 }

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,11 +6,12 @@
 /*   By: tkuramot <tkuramot@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/02 23:57:29 by tkuramot          #+#    #+#             */
-/*   Updated: 2023/09/18 22:30:07 by tkuramot         ###   ########.fr       */
+/*   Updated: 2023/09/18 22:56:29 by tkuramot         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "parser.h"
+#include "lexer.h"
 #include "utils.h"
 
 static bool	expect_pipe(t_token *lst)
@@ -18,6 +19,37 @@ static bool	expect_pipe(t_token *lst)
 	if (!lst || !lst->next)
 		return (false);
 	return (ft_strcmp(lst->next->word, "|") == 0);
+}
+
+static void		arrange_node(t_ast *ast)
+{
+	t_token	*lst = ast->lst;
+	t_token	*tmp;
+	t_token	head;
+	t_token	*cur;
+
+	if (!lst)
+		return;
+	tmp = ast->lst;
+	head.next = NULL;
+	cur = &head;
+	while (tmp)
+	{
+		if (tmp && tmp->type == TK_REDIR_IN)
+		{
+			ft_lstadd_back(&ast->red_in, ft_lstnew(tmp->word));
+			tmp = tmp->next;
+		}
+		if (tmp && tmp->type == TK_REDIR_OUT)
+		{
+			ft_lstadd_back(&ast->red_out, ft_lstnew(tmp->word));
+			tmp = tmp->next;
+		}
+		cur->next = tmp;
+		cur = cur->next;
+		tmp = tmp->next;
+	}
+	ast->argv = head.next;
 }
 
 static t_ast	*parse_cmd(t_token **lst)
@@ -35,6 +67,7 @@ static t_ast	*parse_cmd(t_token **lst)
 	*lst = tmp->next;
 	tmp->next = NULL;
 	node = ast_new_node_cmd(cmd);
+	arrange_node(node);
 	return (node);
 }
 

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: tkuramot <tkuramot@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/02 23:57:29 by tkuramot          #+#    #+#             */
-/*   Updated: 2023/09/18 23:16:56 by tkuramot         ###   ########.fr       */
+/*   Updated: 2023/09/18 23:24:51 by tkuramot         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -45,14 +45,16 @@ static void		arrange_node(t_ast *ast)
 	while (tmp)
 	{
 		if (tmp->type == TK_REDIR_IN && add_redirect(&ast->red_in, &tmp))
+		{
 			continue;
+		}
 		else if (tmp->type == TK_REDIR_OUT && add_redirect(&ast->red_out, &tmp))
 			continue;
 		else if (tmp->type == TK_REDIR_HEREDOC && add_redirect(&ast->red_heredoc, &tmp))
 			continue;
 		else if (tmp->type == TK_REDIR_APPEND && add_redirect(&ast->red_append, &tmp))
 			continue;
-		cur->next = tmp;
+		cur->next = token_copy(tmp);
 		cur = cur->next;
 		tmp = tmp->next;
 	}

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: tkuramot <tkuramot@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/02 23:57:29 by tkuramot          #+#    #+#             */
-/*   Updated: 2023/09/18 22:56:29 by tkuramot         ###   ########.fr       */
+/*   Updated: 2023/09/18 23:16:56 by tkuramot         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,6 +19,15 @@ static bool	expect_pipe(t_token *lst)
 	if (!lst || !lst->next)
 		return (false);
 	return (ft_strcmp(lst->next->word, "|") == 0);
+}
+
+static bool		add_redirect(t_list **redirect, t_token **lst)
+{
+	if (!lst || !*lst || !(*lst)->next)
+		return (false);
+	ft_lstadd_back(redirect, ft_lstnew((*lst)->next->word));
+	*lst = (*lst)->next->next;
+	return (true);
 }
 
 static void		arrange_node(t_ast *ast)
@@ -35,16 +44,14 @@ static void		arrange_node(t_ast *ast)
 	cur = &head;
 	while (tmp)
 	{
-		if (tmp && tmp->type == TK_REDIR_IN)
-		{
-			ft_lstadd_back(&ast->red_in, ft_lstnew(tmp->word));
-			tmp = tmp->next;
-		}
-		if (tmp && tmp->type == TK_REDIR_OUT)
-		{
-			ft_lstadd_back(&ast->red_out, ft_lstnew(tmp->word));
-			tmp = tmp->next;
-		}
+		if (tmp->type == TK_REDIR_IN && add_redirect(&ast->red_in, &tmp))
+			continue;
+		else if (tmp->type == TK_REDIR_OUT && add_redirect(&ast->red_out, &tmp))
+			continue;
+		else if (tmp->type == TK_REDIR_HEREDOC && add_redirect(&ast->red_heredoc, &tmp))
+			continue;
+		else if (tmp->type == TK_REDIR_APPEND && add_redirect(&ast->red_append, &tmp))
+			continue;
 		cur->next = tmp;
 		cur = cur->next;
 		tmp = tmp->next;

--- a/src/utils/error.c
+++ b/src/utils/error.c
@@ -6,7 +6,7 @@
 /*   By: tkuramot <tkuramot@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/20 10:59:15 by tkuramot          #+#    #+#             */
-/*   Updated: 2023/08/27 06:49:09 by tkuramot         ###   ########.fr       */
+/*   Updated: 2023/09/18 22:31:12 by tkuramot         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,4 +17,9 @@ void	fatal_error(char *err)
 {
 	ft_dprintf(STDERR_FILENO, "%s\n", err);
 	exit(1);
+}
+
+void	syntax_error(char *location)
+{
+	ft_dprintf(STDERR_FILENO, "minishell: syntax error near %s\n", location);
 }


### PR DESCRIPTION
```c
typedef struct s_ast t_ast;
struct s_ast
{
	t_node_type	type;
	t_token		*argv;
	t_list		*red_in;
	t_list		*red_out;
	t_list		*red_heredoc;
	t_list		*red_append;
	t_ast		*left;
	t_ast		*right;
	t_token		*lst;
};
```
redirectのファイルまとめた。
argvにはredirectとかredirect元/先のファイル以外の、コマンドと引数だけが入る。
argvは今のコマンド実行に合わせてt_tokenで作ってる
redirectのin, out, heredoc, appendは、libftにあるt_list使ってる。

これに関連してlexerも少し編集してて、t_tokenのノードの種類が増えた
```c
typedef enum e_token_type
{
	TK_WORD,
	TK_PIPE,
	TK_REDIR_IN,
	TK_REDIR_OUT,
	TK_REDIR_APPEND,
	TK_REDIR_HEREDOC,
	TK_EOF,
}	t_token_type;
```

minishell.hにマクロでDEBUGフラグ作ってるから、コマンド実行するときは変更してください