### PR TITLE
fix exec close std

### DIFF
--- a/src/builtin/env_lst_operations.c
+++ b/src/builtin/env_lst_operations.c
@@ -6,15 +6,13 @@
 /*   By: tsishika <tsishika@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/28 21:17:32 by tsishika          #+#    #+#             */
-/*   Updated: 2023/10/01 23:46:16 by tsishika         ###   ########.fr       */
+/*   Updated: 2023/10/04 22:42:00 by tsishika         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "builtin.h"
 #include "utils.h"
 #include <stdlib.h>
-
-int g_cnt = 0;
 
 t_env	*env_lst_node_new(char *new_env)
 {

--- a/src/exec/execute.c
+++ b/src/exec/execute.c
@@ -6,7 +6,7 @@
 /*   By: tsishika <tsishika@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/10 17:03:24 by tkuramot          #+#    #+#             */
-/*   Updated: 2023/10/04 21:33:25 by tsishika         ###   ########.fr       */
+/*   Updated: 2023/10/05 17:28:05 by tsishika         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,7 +34,8 @@ void	traverse_pipe(int std[2], t_list *fd, t_ast *ast, t_env *env, t_list **proc
 	if (ast->type == ND_PIPE)
 	{
 		if (pipe(pp) == -1)
-			fatal_error("pipe");
+			perror("pipe");
+			// fatal_error("pipe");
 		ft_lstadd_back(&fd, ft_lstnew(ft_itoa(pp[0])));
 		ft_lstadd_back(&fd, ft_lstnew(ft_itoa(pp[1])));
 		tmp = std[0];
@@ -119,5 +120,7 @@ void	execute(t_context *ctx)
 		ctx->status = run_simple_cmd(ctx->ast->argv, ctx->env);
 		dup2(std[0], STDIN_FILENO);
 		dup2(std[1], STDOUT_FILENO);
+		close(std[0]);
+		close(std[1]);
 	}
 }

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: tsishika <tsishika@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/19 17:33:13 by tkuramot          #+#    #+#             */
-/*   Updated: 2023/10/05 10:17:05 by tkuramot         ###   ########.fr       */
+/*   Updated: 2023/10/05 17:34:27 by tsishika         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,6 +44,11 @@ int	main(void)
 	ctx.status = 0;
 	while (true)
 	{
+		int fd;
+		fd = dup(1);
+		ft_dprintf(1, "fd = %d\n", fd);
+		close(fd);
+
 		ctx.sys_error = false;
 		set_idle_sig_handler();
 		line = readline("\x1b[32mminishell$ \x1b[0m");


### PR DESCRIPTION
とりあえずレビュー中に見つけたところはcloseしておきました。
main関数内でfd確認できるようになってます。
```
int fd = dup(1);
ft_dprintf(1, "fd = %d\n", fd);
clsoe(fd)
```
コマンド実行時、fdは変わんないけどls|ls|ls....はまだ落ちるのでまだなんかありそう。